### PR TITLE
We fix the COPY command for new BSON types, and its tests.

### DIFF
--- a/backend/postgresql/pom.xml
+++ b/backend/postgresql/pom.xml
@@ -64,6 +64,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.torodb.engine.backend</groupId>
             <artifactId>test-tools</artifactId>
             <version>${project.version}</version>

--- a/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/PostgreSqlValueToCopyConverter.java
+++ b/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/PostgreSqlValueToCopyConverter.java
@@ -18,6 +18,9 @@
 
 package com.torodb.backend.postgresql.converters;
 
+import com.torodb.backend.postgresql.converters.jooq.MongoDbPointerValueConverter;
+import com.torodb.backend.postgresql.converters.jooq.MongoJavascriptWithScopeValueConverter;
+import com.torodb.backend.postgresql.converters.jooq.MongoRegexValueConverter;
 import com.torodb.backend.postgresql.converters.util.CopyEscaper;
 import com.torodb.common.util.HexUtils;
 import com.torodb.common.util.TextEscaper;
@@ -183,11 +186,7 @@ public class PostgreSqlValueToCopyConverter implements KvValueVisitor<Void, Stri
 
   @Override
   public Void visit(KvMongoJavascriptWithScope value, StringBuilder arg) {
-    arg.append("{\"js\": \"");
-    appendJsonString(arg, value.getJs());
-    arg.append("\", \"scope\": \"");
-    appendJsonString(arg, value.getScopeAsString());
-    arg.append("\"}");
+    ESCAPER.appendEscaped(arg, MongoJavascriptWithScopeValueConverter.CONVERTER.to(value));
 
     return null;
   }
@@ -212,35 +211,22 @@ public class PostgreSqlValueToCopyConverter implements KvValueVisitor<Void, Stri
 
   @Override
   public Void visit(KvMongoRegex value, StringBuilder arg) {
-    arg.append("{\"options\": \"");
-    appendJsonString(arg, value.getOptionsAsText());
-    arg.append("\", \"pattern\": \"");
-    appendJsonString(arg, value.getPattern());
-    arg.append("\"}");
+    ESCAPER.appendEscaped(arg, MongoRegexValueConverter.CONVERTER.to(value));
+
     return null;
   }
 
   @Override
   public Void visit(KvMongoDbPointer value, StringBuilder arg) {
-    arg.append("{\"namespace\": \"");
-    appendJsonString(arg, value.getNamespace());
-    arg.append("\", \"objectId\": \"");
-    visit(value.getId(), arg);
-    arg.append("\"}");
+    ESCAPER.appendEscaped(arg, MongoDbPointerValueConverter.CONVERTER.to(value));
 
     return null;
   }
 
   @Override
   public Void visit(KvDeprecated value, StringBuilder arg) {
-    arg.append(value.toString());
+    ESCAPER.appendEscaped(arg, value.toString());
     return null;
-  }
-
-  private StringBuilder appendJsonString(StringBuilder arg, String in) {
-    final String jsonb = in.replaceAll("\\\"", "\\\\\"");
-    ESCAPER.appendEscaped(arg, jsonb);
-    return arg;
   }
 
 }

--- a/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/jooq/MongoDbPointerValueConverter.java
+++ b/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/jooq/MongoDbPointerValueConverter.java
@@ -41,8 +41,11 @@ public class MongoDbPointerValueConverter
 
   private static final long serialVersionUID = 1L;
 
+  public static final MongoDbPointerValueConverter CONVERTER =
+      new MongoDbPointerValueConverter();
+
   public static final DataTypeForKv<KvMongoDbPointer> TYPE =
-      JsonbBinding.fromKvValue(KvMongoDbPointer.class, new MongoDbPointerValueConverter());
+      JsonbBinding.fromKvValue(KvMongoDbPointer.class, CONVERTER);
 
   @Override
   public KvType getErasuredType() {

--- a/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/jooq/MongoJavascriptWithScopeValueConverter.java
+++ b/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/jooq/MongoJavascriptWithScopeValueConverter.java
@@ -39,9 +39,12 @@ public class MongoJavascriptWithScopeValueConverter
 
   private static final long serialVersionUID = 1L;
 
+  public static final MongoJavascriptWithScopeValueConverter CONVERTER =
+      new MongoJavascriptWithScopeValueConverter();
+
   public static final DataTypeForKv<KvMongoJavascriptWithScope> TYPE =
       JsonbBinding.fromKvValue(
-          KvMongoJavascriptWithScope.class, new MongoJavascriptWithScopeValueConverter());
+          KvMongoJavascriptWithScope.class, CONVERTER);
 
   @Override
   public KvType getErasuredType() {

--- a/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/jooq/MongoRegexValueConverter.java
+++ b/backend/postgresql/src/main/java/com/torodb/backend/postgresql/converters/jooq/MongoRegexValueConverter.java
@@ -39,8 +39,11 @@ public class MongoRegexValueConverter implements KvValueConverter<String, String
 
   private static final long serialVersionUID = 1L;
 
+  public static final MongoRegexValueConverter CONVERTER =
+      new MongoRegexValueConverter();
+
   public static final DataTypeForKv<KvMongoRegex> TYPE =
-      JsonbBinding.fromKvValue(KvMongoRegex.class, new MongoRegexValueConverter());
+      JsonbBinding.fromKvValue(KvMongoRegex.class, CONVERTER);
 
   @Override
   public KvType getErasuredType() {

--- a/backend/postgresql/src/test/java/com/torodb/backend/postgresql/converters/PostgreSqlValueToCopyConverterTest.java
+++ b/backend/postgresql/src/test/java/com/torodb/backend/postgresql/converters/PostgreSqlValueToCopyConverterTest.java
@@ -175,7 +175,7 @@ public class PostgreSqlValueToCopyConverterTest {
                                     .put("a", KvInteger.of(123))
                                     .put("b", KvLong.of(0))
                                     .build()))),
-                    "{\"js\": \"alert('hello');\", \"scope\": \"{a : 123, b : 0}\"}"
+                    "{\"js\":\"alert('hello');\",\"scope\":\"{a : 123, b : 0}\"}"
                   },
                   //{"ZeroDecimal128", KvDecimal128.of(0, 0), "0." + String.format("%6176s", "").replace(' ', '0')},
                   //{"NaNDecimal128", KvDecimal128.of(0x7c00000000000000L, 0), "0." + String.format("%6176s", "").replace(' ', '0')},
@@ -191,7 +191,8 @@ public class PostgreSqlValueToCopyConverterTest {
                     "(-1000000000000000000,false,false,false)"
                   },
                   //{"TinyDecimal128", KvDecimal128.of(new BigDecimal("0.0000000000000000001")), "0.0000000000000000001"},
-                  {"MongoRegex", KvMongoRegex.of("pattern", "esd"), "{\"options\": \"esd\", \"pattern\": \"pattern\"}"},
+                  {"MongoRegex", KvMongoRegex.of("pattern", "esd"), "{\"pattern\":\"pattern\",\"options\":\"esd\"}"},
+                  {"StrangeMongoRegex", KvMongoRegex.of("pa'tt\"e/rn", "esd"), "{\"pattern\":\"pa'tt\\\\\"e/rn\",\"options\":\"esd\"}"},
                   {"Timestamp", new DefaultKvMongoTimestamp(27, 3), "(27,3)"},
                   {
                     "DbPointer",
@@ -199,7 +200,7 @@ public class PostgreSqlValueToCopyConverterTest {
                         "namespace",
                         new ByteArrayKvMongoObjectId(
                             new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc})),
-                    "{\"namespace\": \"namespace\", \"objectId\": \"\\\\x0102030405060708090A0B0C\"}"
+                    "{\"namespace\":\"namespace\",\"objectId\":\"\\\\u0001\\\\u0002\\\\u0003\\\\u0004\\\\u0005\\\\u0006\\\\u0007\\\\b\\\\t\\\\n\\\\u000b\\\\f\"}"
                   },
                 })
             .collect(Collectors.toList());

--- a/backend/postgresql/src/test/java/com/torodb/backend/postgresql/converters/PostgreSqlValueToCopyConverterTest.java
+++ b/backend/postgresql/src/test/java/com/torodb/backend/postgresql/converters/PostgreSqlValueToCopyConverterTest.java
@@ -175,7 +175,7 @@ public class PostgreSqlValueToCopyConverterTest {
                                     .put("a", KvInteger.of(123))
                                     .put("b", KvLong.of(0))
                                     .build()))),
-                    "alert('hello');{a : 123, b : 0}"
+                    "{\"js\": \"alert('hello');\", \"scope\": \"{a : 123, b : 0}\"}"
                   },
                   //{"ZeroDecimal128", KvDecimal128.of(0, 0), "0." + String.format("%6176s", "").replace(' ', '0')},
                   //{"NaNDecimal128", KvDecimal128.of(0x7c00000000000000L, 0), "0." + String.format("%6176s", "").replace(' ', '0')},
@@ -183,15 +183,15 @@ public class PostgreSqlValueToCopyConverterTest {
                   {
                     "HighDecimal128",
                     KvDecimal128.of(new BigDecimal("1000000000000000000000")),
-                    "1000000000000000000000"
+                    "(1000000000000000000000,false,false,false)"
                   },
                   {
                     "NegativeDecimal128",
                     KvDecimal128.of(new BigDecimal("-1000000000000000000")),
-                    "-1000000000000000000"
+                    "(-1000000000000000000,false,false,false)"
                   },
                   //{"TinyDecimal128", KvDecimal128.of(new BigDecimal("0.0000000000000000001")), "0.0000000000000000001"},
-                  {"MongoRegex", KvMongoRegex.of("pattern", "esd"), "pattern,esd"},
+                  {"MongoRegex", KvMongoRegex.of("pattern", "esd"), "{\"options\": \"esd\", \"pattern\": \"pattern\"}"},
                   {"Timestamp", new DefaultKvMongoTimestamp(27, 3), "(27,3)"},
                   {
                     "DbPointer",
@@ -199,7 +199,7 @@ public class PostgreSqlValueToCopyConverterTest {
                         "namespace",
                         new ByteArrayKvMongoObjectId(
                             new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc})),
-                    "(namespace,\\\\x0102030405060708090A0B0C)"
+                    "{\"namespace\": \"namespace\", \"objectId\": \"\\\\x0102030405060708090A0B0C\"}"
                   },
                 })
             .collect(Collectors.toList());


### PR DESCRIPTION
We could delete these tests, because they are comparing strings and thus they're not the best tests, but they can be useful (in fact, if we had had them before, we would have discovered this bug much earlier)