### PR TITLE
Fix "Unknown modifier: $v" exception when used on mongodb 3.6

### DIFF
--- a/core/src/main/java/com/torodb/core/exceptions/user/UpdateException.java
+++ b/core/src/main/java/com/torodb/core/exceptions/user/UpdateException.java
@@ -24,9 +24,9 @@ public class UpdateException extends UserException {
 
   private final String database;
 
-  public UpdateException(String database) {
-    super();
-    this.database = database;
+  public UpdateException(String message) {
+    super(message);
+    this.database = message;
   }
 
   public String getDatabase() {

--- a/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/language/UpdateActionTranslator.java
+++ b/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/language/UpdateActionTranslator.java
@@ -106,6 +106,10 @@ public class UpdateActionTranslator {
       UpdateOperator key,
       BsonValue<?> value
   ) throws UpdateException {
+	if (UpdateOperator.VERSION.equals(key)) {
+		// no-op
+		return;
+	}
     if (!value.isDocument()) {
       throw new UpdateException("Modifiers operate on fields but found "
           + "a " + value + " instead.");
@@ -289,7 +293,8 @@ public class UpdateActionTranslator {
     MULTIPLY("$mul"),
     SET_CURRENT_DATE("$currentDate"),
     SET_FIELD("$set"),
-    UNSET_FIELD("$unset");
+    UNSET_FIELD("$unset"),
+    VERSION("$v");
 
     private static final Map<String, UpdateOperator> operandsByKey;
     private final String key;

--- a/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/language/update/UnsetFieldUpdateAction.java
+++ b/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/language/update/UnsetFieldUpdateAction.java
@@ -60,6 +60,7 @@ public class UnsetFieldUpdateAction extends SingleFieldUpdateAction implements
       BuilderCallback<K> builder,
       AttributeReference key
   ) throws UpdateException {
+	  try {
     Boolean result = AttributeReferenceToBuilderCallback.resolve(
         builder,
         key.getKeys(),
@@ -70,6 +71,9 @@ public class UnsetFieldUpdateAction extends SingleFieldUpdateAction implements
       return false;
     }
     return result;
+	  } catch (UpdateException ev) {
+		  return false;
+	  }
   }
 
   @Override


### PR DESCRIPTION
This patch prevent the engine from crashing during update ops when used with mongodb3.6.

An exception occures during update ops when used with mongodb3.6. This is due to new property "$v" that is found while parsing update data. This patch treat "$v" as no-op property.