### PR TITLE
Fix UpdateException when unsetting array items.

### DIFF
--- a/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/language/update/UnsetFieldUpdateAction.java
+++ b/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/language/update/UnsetFieldUpdateAction.java
@@ -60,6 +60,7 @@ public class UnsetFieldUpdateAction extends SingleFieldUpdateAction implements
       BuilderCallback<K> builder,
       AttributeReference key
   ) throws UpdateException {
+	  try {
     Boolean result = AttributeReferenceToBuilderCallback.resolve(
         builder,
         key.getKeys(),
@@ -70,6 +71,9 @@ public class UnsetFieldUpdateAction extends SingleFieldUpdateAction implements
       return false;
     }
     return result;
+	  } catch (UpdateException ev) {
+		  return false;
+	  }
   }
 
   @Override


### PR DESCRIPTION
When torodb receives unset op with statement such as {$unset: {'foo.3.bar": true}} it throws an UpdateException.
This fix replicates how UpdateException are treated on set op.